### PR TITLE
Implement AsyncBufRead and related methods on Reader and Writer for directly accessing the buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,8 +557,9 @@ impl Reader {
 
     /// Poll for data to become available in the pipe or the write side to be closed.
     ///
-    /// Returns `Poll::Ready(true)` when data is ready. Call `peek_buf()` to access the
-    /// data, and `consume()` to advance the read position.
+    /// Returns `Poll::Ready(true)` when data is ready. Call
+    /// [`peek_buf()`][Self::peek_buf] to access the data, and
+    /// [`consume()`][Self::consume] to advance the read position.
     ///
     /// A return value of `Poll::Ready(false)` indicates that the pipe is closed.
     ///
@@ -569,7 +570,7 @@ impl Reader {
     /// require the `std` feature. It separates the polling, buffer access, and consume steps
     /// for compatibility with `poll_fn`'s lifetime requirements.
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use futures_lite::{future, prelude::*};
@@ -1022,8 +1023,9 @@ impl Writer {
     /// Poll for available space in the pipe or the read side to be closed.
     ///
     /// Returns `Poll::Ready(true)` when space is available to write. Call
-    /// `write_buf()` to obtain a mutable slice of the buffer to write into,
-    /// then call [`produced(n)`] once the data is written.
+    /// [`write_buf()`][Self::write_buf] to obtain a mutable slice of the buffer
+    /// to write into, then call [`produced(n)`][Self::produced] once the data
+    /// is written.
     ///
     /// A return value of `Poll::Ready(false)` indicates that the pipe is
     /// closed.
@@ -1032,7 +1034,7 @@ impl Writer {
     /// register the waker to receive a notification when space becomes
     /// available or the read end is closed.
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use futures_lite::{future, prelude::*};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,16 @@ impl Pipe {
             (2 * self.cap) - (head - tail)
         }
     }
+
+    /// Given an index in `0..2*cap`, returns the real index in `0..cap`.
+    #[inline]
+    fn real_index(&self, i: usize) -> usize {
+        if i < self.cap {
+            i
+        } else {
+            i - self.cap
+        }
+    }
 }
 
 impl Reader {
@@ -571,6 +581,18 @@ impl Reader {
         }
     }
 
+    /// Get the number of bytes available to read without synchronization.
+    #[inline]
+    fn available_data(&self) -> usize {
+        let a = self.head;
+        let b = self.tail;
+        if a <= b {
+            b - a
+        } else {
+            2 * self.inner.cap - (a - b)
+        }
+    }
+
     /// Reads bytes from this reader and writes into blocking `dest`.
     #[inline]
     fn drain_inner<W: WriteLike>(
@@ -580,22 +602,13 @@ impl Reader {
     ) -> Poll<Result<usize, W::Error>> {
         let cap = self.inner.cap;
 
-        // Calculates the distance between two indices.
-        let distance = |a: usize, b: usize| {
-            if a <= b {
-                b - a
-            } else {
-                2 * cap - (a - b)
-            }
-        };
-
         // If the pipe appears to be empty...
-        if distance(self.head, self.tail) == 0 {
+        if self.available_data() == 0 {
             // Reload the tail in case it's become stale.
             self.tail = self.inner.tail.load(Ordering::Acquire);
 
             // If the pipe is now really empty...
-            if distance(self.head, self.tail) == 0 {
+            if self.available_data() == 0 {
                 // Register the waker.
                 if let Some(cx) = cx.as_mut() {
                     self.inner.reader.register(cx.waker());
@@ -606,7 +619,7 @@ impl Reader {
                 self.tail = self.inner.tail.load(Ordering::Acquire);
 
                 // If the pipe is still empty...
-                if distance(self.head, self.tail) == 0 {
+                if self.available_data() == 0 {
                     // Check whether the pipe is closed or just empty.
                     if self.inner.closed.load(Ordering::Relaxed) {
                         return Poll::Ready(Ok(0));
@@ -625,27 +638,19 @@ impl Reader {
             ready!(maybe_yield(&mut self.rng, cx));
         }
 
-        // Given an index in `0..2*cap`, returns the real index in `0..cap`.
-        let real_index = |i: usize| {
-            if i < cap {
-                i
-            } else {
-                i - cap
-            }
-        };
-
         // Number of bytes read so far.
         let mut count = 0;
 
         loop {
             // Calculate how many bytes to read in this iteration.
             let n = (128 * 1024) // Not too many bytes in one go - better to wake the writer soon!
-                .min(distance(self.head, self.tail)) // No more than bytes in the pipe.
-                .min(cap - real_index(self.head)); // Don't go past the buffer boundary.
+                .min(self.available_data()) // No more than bytes in the pipe.
+                .min(cap - self.inner.real_index(self.head)); // Don't go past the buffer boundary.
 
             // Create a slice of data in the pipe buffer.
-            let pipe_slice =
-                unsafe { slice::from_raw_parts(self.inner.buffer.add(real_index(self.head)), n) };
+            let pipe_slice = unsafe {
+                slice::from_raw_parts(self.inner.buffer.add(self.inner.real_index(self.head)), n)
+            };
 
             // Copy bytes from the pipe buffer into `dest`.
             let n = dest.write(pipe_slice)?;
@@ -871,6 +876,18 @@ impl Writer {
         }
     }
 
+    /// Get the free space in bytes that can be written without synchronization.
+    #[inline]
+    fn available_space(&self) -> usize {
+        let a = self.head;
+        let b = self.tail;
+        if a <= b {
+            self.inner.cap - (b - a)
+        } else {
+            (a - b) - self.inner.cap
+        }
+    }
+
     /// Reads bytes from blocking `src` and writes into this writer.
     #[inline]
     fn fill_inner<R: ReadLike>(
@@ -883,23 +900,15 @@ impl Writer {
             return Poll::Ready(Ok(0));
         }
 
-        // Calculates the distance between two indices.
         let cap = self.inner.cap;
-        let distance = |a: usize, b: usize| {
-            if a <= b {
-                b - a
-            } else {
-                2 * cap - (a - b)
-            }
-        };
 
         // If the pipe appears to be full...
-        if distance(self.head, self.tail) == cap {
+        if self.available_space() == 0 {
             // Reload the head in case it's become stale.
             self.head = self.inner.head.load(Ordering::Acquire);
 
-            // If the pipe is now really empty...
-            if distance(self.head, self.tail) == cap {
+            // If the pipe is now really still full...
+            if self.available_space() == 0 {
                 // Register the waker.
                 if let Some(cx) = cx.as_mut() {
                     self.inner.writer.register(cx.waker());
@@ -910,7 +919,7 @@ impl Writer {
                 self.head = self.inner.head.load(Ordering::Acquire);
 
                 // If the pipe is still full...
-                if distance(self.head, self.tail) == cap {
+                if self.available_space() == 0 {
                     // Check whether the pipe is closed or just full.
                     if self.inner.closed.load(Ordering::Relaxed) {
                         return Poll::Ready(Ok(0));
@@ -929,15 +938,6 @@ impl Writer {
             ready!(maybe_yield(&mut self.rng, cx));
         }
 
-        // Given an index in `0..2*cap`, returns the real index in `0..cap`.
-        let real_index = |i: usize| {
-            if i < cap {
-                i
-            } else {
-                i - cap
-            }
-        };
-
         // Number of bytes written so far.
         let mut count = 0;
 
@@ -945,12 +945,12 @@ impl Writer {
             // Calculate how many bytes to write in this iteration.
             let n = (128 * 1024) // Not too many bytes in one go - better to wake the reader soon!
                 .min(self.zeroed_until * 2 + 4096) // Don't zero too many bytes when starting.
-                .min(cap - distance(self.head, self.tail)) // No more than space in the pipe.
-                .min(cap - real_index(self.tail)); // Don't go past the buffer boundary.
+                .min(self.available_space()) // No more than space in the pipe.
+                .min(cap - self.inner.real_index(self.tail)); // Don't go past the buffer boundary.
 
             // Create a slice of available space in the pipe buffer.
             let pipe_slice_mut = unsafe {
-                let from = real_index(self.tail);
+                let from = self.inner.real_index(self.tail);
                 let to = from + n;
 
                 // Make sure all bytes in the slice are initialized.

--- a/tests/pipe.rs
+++ b/tests/pipe.rs
@@ -48,6 +48,42 @@ fn read() {
         .run();
 }
 
+#[test]
+fn buf_read() {
+    use futures_lite::io::AsyncBufReadExt;
+    let (mut r, mut w) = pipe(8);
+    let ms = Duration::from_micros;
+
+    Parallel::new()
+        .add(move || {
+            let mut line = String::new();
+            future::block_on(r.read_line(&mut line)).unwrap();
+            assert_eq!(line, "hello world\n");
+            line.clear();
+
+            future::block_on(r.read_line(&mut line)).unwrap();
+            assert_eq!(line, "line2\n");
+            line.clear();
+
+            future::block_on(r.read_line(&mut line)).unwrap();
+            assert_eq!(line, "line3");
+        })
+        .add(move || {
+            sleep(ms(500));
+            future::block_on(w.write_all(b"hello world\nline2\n")).unwrap();
+            sleep(ms(100));
+            future::block_on(w.write_all(b"line3")).unwrap();
+        })
+        .run();
+}
+
+#[test]
+#[should_panic]
+fn excessive_consume() {
+    let (mut r, _) = pipe(8);
+    r.consume(1);
+}
+
 #[should_panic]
 #[test]
 fn zero_cap_pipe() {

--- a/tests/pipe.rs
+++ b/tests/pipe.rs
@@ -84,6 +84,13 @@ fn excessive_consume() {
     r.consume(1);
 }
 
+#[test]
+#[should_panic]
+fn excessive_produced() {
+    let (_, mut w) = pipe(8);
+    w.produced(9);
+}
+
 #[should_panic]
 #[test]
 fn zero_cap_pipe() {


### PR DESCRIPTION
AsyncBufRead is useful for anything parsing the received data to avoid another copy to an intermediate buffer.

There is no standard trait for the Writer side, but my use case is for making multiple readers at different positions over the same file descriptor using `read_at` to virtualize the file cursor. The existing API can only pass a buffer to `read` and not `read_at`.