### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.2.5
+
+- Add functions to allow for buffered reading and writing. (#27)
+- Fix a bug where closing the `Writer` after writing can cause the `Reader` to
+  lose bytes. (#31)
+
 # Version 0.2.4
 
 - Update doctests to be more reliable. (#19)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "piper"
 repository = "https://github.com/smol-rs/piper"
-version = "0.2.4"
+version = "0.2.5"
 rust-version = "1.36"
 
 [features]


### PR DESCRIPTION
- Add functions to allow for buffered reading and writing. (#27)
- Fix a bug where closing the `Writer` after writing can cause the `Reader` to
  lose bytes. (#31)

